### PR TITLE
remove redundant checkout

### DIFF
--- a/.github/actions/codeql-action/action.yml
+++ b/.github/actions/codeql-action/action.yml
@@ -4,9 +4,6 @@ description: "Simplify running CodeQL on Python"
 runs:
   using: "composite"
   steps:
-  - name: Checkout repository
-    uses: actions/checkout@v4
-
   # Initializes the CodeQL tools for scanning.
   - name: Initialize CodeQL
     uses: github/codeql-action/init@v3

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,7 @@ permissions:
   contents: read
 
 jobs:
+
   prebuild:
     name: Pre build formatting
     runs-on: ubuntu-latest
@@ -14,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
     - name: format with black
       uses: psf/black@stable
-      
+
   codeql:
     name: CodeQL scan
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,4 +37,4 @@ jobs:
       uses: zaproxy/action-baseline@v0.12.0
       with:
         target: 'http://localhost:5000'
-        allow_issue_writing: "false"
+        allow_issue_writing: 'false'

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv*
 
 __pycache__
 *egg-info
+dist
 
 events.csv
 


### PR DESCRIPTION
Workflow checks out the repo before invoking the custom CodeQL action, but that action's first step is also a checkout; this is probably not necessary.